### PR TITLE
add support for passing extra context to tx-fns

### DIFF
--- a/src/gelatinous_cube/api.clj
+++ b/src/gelatinous_cube/api.clj
@@ -38,10 +38,12 @@
           norm-maps))
 
 (defn absorb
-  [conn extras {:keys [norm-maps only-norms]
-                :or {only-norms (map :name norm-maps)}}]
-  (let [adapted-norms (-> norm-maps
-                          (norm-maps-by-name only-norms)
-                          impl/adapt!)]
-    (impl/ensure-tracking-schema! conn *tracking-attr*)
-    (absorb-norms conn extras adapted-norms)))
+  ([conn norms]
+   (absorb conn {} norms))
+  ([conn extras {:keys [norm-maps only-norms]
+                 :or {only-norms (map :name norm-maps)}}]
+   (let [adapted-norms (-> norm-maps
+                           (norm-maps-by-name only-norms)
+                           impl/adapt!)]
+     (impl/ensure-tracking-schema! conn *tracking-attr*)
+     (absorb-norms conn extras adapted-norms))))

--- a/src/gelatinous_cube/impl.clj
+++ b/src/gelatinous_cube/impl.clj
@@ -44,14 +44,14 @@
     (tx! conn tx-data)))
 
 (defn transact-norm-tx-data
-  [conn norm-map tracking-attr]
+  [conn extras norm-map tracking-attr]
   (into [{tracking-attr (:name norm-map)}]
-        (tx-sources/tx-data-for-norm conn norm-map)))
+        (tx-sources/tx-data-for-norm conn extras norm-map)))
 
 (defn transact-norm!
   "Transact and record tracking attr for norm."
-  [conn norm-map tracking-attr]
-  (tx! conn (transact-norm-tx-data conn norm-map tracking-attr)))
+  [conn extras norm-map tracking-attr]
+  (tx! conn (transact-norm-tx-data conn extras norm-map tracking-attr)))
 
 (defn needed?
   [conn norm-map tracking-attr]

--- a/src/gelatinous_cube/tx_sources.clj
+++ b/src/gelatinous_cube/tx_sources.clj
@@ -19,7 +19,7 @@
 (defn eval-tx-fn
   [conn extras tx-fn]
   (try (let [resolved-tx-fn (requiring-resolve tx-fn)]
-         (if (->> resolved-tx-fn var meta :arglists (some #(or (= '& (first %)) (>= (count %) 2))))
+         (if (->> resolved-tx-fn meta :arglists (some #(or (= '& (first %)) (>= (count %) 2))))
            (resolved-tx-fn conn extras)
            (resolved-tx-fn conn)))
        (catch Throwable t

--- a/src/gelatinous_cube/tx_sources.clj
+++ b/src/gelatinous_cube/tx_sources.clj
@@ -19,7 +19,7 @@
 (defn eval-tx-fn
   [conn extras tx-fn]
   (try (let [resolved-tx-fn (requiring-resolve tx-fn)]
-         (if (->> resolved-tx-fn meta :arglists (some #(or (= '& (first %)) (>= (count %) 2))))
+         (if (->> resolved-tx-fn meta :arglists (some #(or (= '& (first %)) (< 1 (count %)))))
            (resolved-tx-fn conn extras)
            (resolved-tx-fn conn)))
        (catch Throwable t

--- a/test-resources/sample-config.edn
+++ b/test-resources/sample-config.edn
@@ -32,4 +32,10 @@
   :tx-fn sample-tx-fns.fix-user-zip/migrate
   :mutable true}
 
+ ;; We're going international and decided to shard our DB by country. It's
+ ;; time to add country codes to all phone numbers. Each migration execution
+ ;; will be parameterized with the appropriate country code.
+ {:name :add-country-code
+  :tx-fn sample-tx-fns.add-country-codes/migrate}
+
  ]

--- a/test-resources/sample_tx_fns/add_country_codes.clj
+++ b/test-resources/sample_tx_fns/add_country_codes.clj
@@ -1,0 +1,11 @@
+(ns sample-tx-fns.add-country-codes
+  (:require [datomic.client.api :as d]))
+
+
+(defn migrate [conn {:keys [country-code] :or {country-code "+1"}}]
+  (into []
+        (map (fn [[user-eid tel]]
+               [:db/add user-eid :user/tel (str country-code "-" tel)]))
+        (d/q '[:find ?user ?tel
+               :where [?user :user/tel ?tel]]
+             (d/db conn))))


### PR DESCRIPTION
Adds optional support for a 2nd argument to `tx-fn` which contains `extras`, a value provided to `absorb` and simply passed through. The purpose is to use `extras` to provide additional context or component/integrant systems to `tx-fn`, as some migrations may be functions of more than a single database.